### PR TITLE
Product list page

### DIFF
--- a/public/image/product/member/MemberFull.svg
+++ b/public/image/product/member/MemberFull.svg
@@ -1,0 +1,21 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 10C0 4.47715 4.47715 0 10 0H30C35.5228 0 40 4.47715 40 10V30C40 35.5228 35.5228 40 30 40H10C4.47715 40 0 35.5228 0 30V10Z" fill="#45C1FF"/>
+<g clip-path="url(#clip0_264_661)">
+<rect x="8" y="14" width="8" height="12" rx="4" fill="white"/>
+<circle cx="15" cy="20" r="4" fill="black"/>
+</g>
+<rect x="7.25" y="13.25" width="9.5" height="13.5" rx="4.75" stroke="black" stroke-width="1.5"/>
+<g clip-path="url(#clip1_264_661)">
+<rect x="24" y="14" width="8" height="12" rx="4" fill="white"/>
+<circle cx="31" cy="20" r="4" fill="black"/>
+</g>
+<rect x="23.25" y="13.25" width="9.5" height="13.5" rx="4.75" stroke="black" stroke-width="1.5"/>
+<defs>
+<clipPath id="clip0_264_661">
+<rect x="8" y="14" width="8" height="12" rx="4" fill="white"/>
+</clipPath>
+<clipPath id="clip1_264_661">
+<rect x="24" y="14" width="8" height="12" rx="4" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/public/image/product/member/MemberLeft.svg
+++ b/public/image/product/member/MemberLeft.svg
@@ -1,0 +1,21 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 10C0 4.47715 4.47715 0 10 0H30C35.5228 0 40 4.47715 40 10V30C40 35.5228 35.5228 40 30 40H10C4.47715 40 0 35.5228 0 30V10Z" fill="#F5F5F5"/>
+<g clip-path="url(#clip0_264_677)">
+<rect x="8" y="14" width="8" height="12" rx="4" fill="white"/>
+<circle cx="15" cy="20" r="4" fill="#7D7D7D"/>
+</g>
+<rect x="7.25" y="13.25" width="9.5" height="13.5" rx="4.75" stroke="#7D7D7D" stroke-width="1.5"/>
+<g clip-path="url(#clip1_264_677)">
+<rect x="24" y="14" width="8" height="12" rx="4" fill="white"/>
+<circle cx="31" cy="20" r="4" fill="#7D7D7D"/>
+</g>
+<rect x="23.25" y="13.25" width="9.5" height="13.5" rx="4.75" stroke="#7D7D7D" stroke-width="1.5"/>
+<defs>
+<clipPath id="clip0_264_677">
+<rect x="8" y="14" width="8" height="12" rx="4" fill="white"/>
+</clipPath>
+<clipPath id="clip1_264_677">
+<rect x="24" y="14" width="8" height="12" rx="4" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/product/party-card/index.tsx
+++ b/src/components/product/party-card/index.tsx
@@ -1,70 +1,79 @@
-import React from "react";
+import { Button, Typo } from "@/components/ui";
+import { PartyAvatar } from "@/components/product";
+import s from "./styles.module.scss";
 
-import { Typo } from "@/components/ui";
-import type { Plan } from "@/types/product";
-import { getPartyEndDateText } from "@/utils/date";
-
-import PartyAvatar from "../party-avatar";
-
-import styles from "./styles.module.scss";
-
-interface PartyCardProps {
-  party: Plan;
+interface Props {
   productImage: string;
-  onClick?: () => void;
-  className?: string;
+  productName: string;
+  productPrice: string;
+  daysLeft: string;
+  membersLeft: string;
+  currentMembers?: number; // 현재 참여한 멤버 수
+  maxMembers?: number; // 최대 멤버 수
+  isParty: boolean;
 }
 
-const PartyCard: React.FC<PartyCardProps> = ({
-  party,
-  productImage,
-  onClick,
-  className,
-}) => {
-  const { name, price, participants, maxParticipants, endDate } = party;
-
-  const remainingSpots = maxParticipants - participants.length;
-  const isFull = remainingSpots <= 0;
+export default function PartyCard({ 
+  productImage, 
+  productName, 
+  productPrice, 
+  daysLeft, 
+  membersLeft, 
+  currentMembers = 3,
+  maxMembers = 6,
+  isParty = false
+}: Props) {
+  
+  // 파티 아바타들을 렌더링하는 함수
+  const renderPartyAvatars = () => {
+    const avatars = [];
+    
+    // 현재 참여한 멤버들의 아바타
+    for (let i = 0; i < currentMembers; i++) {
+      avatars.push(
+        <PartyAvatar 
+          key={`member-${i}`} 
+          size="sm" 
+        />
+      );
+    }
+    
+    // 빈 자리들 (비활성화된 아바타)
+    for (let i = currentMembers; i < maxMembers; i++) {
+      avatars.push(
+        <PartyAvatar 
+          key={`empty-${i}`} 
+          size="sm" 
+          disabled 
+        />
+      );
+    }
+    
+    return avatars;
+  };
 
   return (
-    <div
-      className={`${styles.partyCard} ${className || ""}`}
-      onClick={onClick}
-      role={onClick ? "button" : undefined}
-      tabIndex={onClick ? 0 : undefined}
-    >
-      <div className={styles.partyInfo}>
-        <div className={styles.partyInfoLeft}>
-          {productImage && (
-            <img
-              className={styles.logo}
-              src={productImage}
-              alt={`${name} 로고`}
-            />
-          )}
-          <Typo.BodyLarge>{name}</Typo.BodyLarge>
+    <div className={s.container}>
+      <div className={s.header}></div>
+        <div className={s.product_id}>
+          <img src={productImage} alt={productName} width={26} height={26}/>
+          <Typo.BodyLarge>{productName}</Typo.BodyLarge>
+          <Typo.BodyLarge>{productPrice}원</Typo.BodyLarge>
         </div>
-        <Typo.BodyLarge>{price.toLocaleString()}원</Typo.BodyLarge>
-      </div>
-
-      <div className={styles.avatars}>
-        {Array.from({ length: maxParticipants }).map((_, index) => (
-          <PartyAvatar
-            key={index}
-            size="md"
-            disabled={index >= participants.length}
-          />
-        ))}
-      </div>
-
-      <div className={styles.footer}>
-        <Typo.Subtext>{getPartyEndDateText(endDate)}</Typo.Subtext>
-        <Typo.Subtext>
-          {isFull ? "마감" : `${remainingSpots}자리 남음`}
-        </Typo.Subtext>
-      </div>
+        {isParty && (
+          <div className={s.member}>
+          {renderPartyAvatars()}
+        </div>
+        )}
+        <div className={s.subscription}>
+          <Typo.Subtext>{daysLeft}</Typo.Subtext>
+          {isParty ? (
+            <Typo.Subtext>{membersLeft}자리 남음</Typo.Subtext>
+          ) : (
+            <Typo.Subtext>{membersLeft}명 참여중</Typo.Subtext>
+          )}
+        </div>
+        <Button size="large" variant="primary" fullWidth>파티 참여하기</Button>
     </div>
-  );
-};
-
-export default PartyCard;
+  )
+}

--- a/src/components/product/party-card/index.tsx
+++ b/src/components/product/party-card/index.tsx
@@ -1,79 +1,60 @@
-import { Button, Typo } from "@/components/ui";
-import { PartyAvatar } from "@/components/product";
 import s from "./styles.module.scss";
+import PartyCardHead from "./party-card-head";
+import PartyCardIsParty from "./party-card-isparty";
+import PartyCardInfo from "./party-card-info";
+import PartyCardButton from "./party-card-button";
 
 interface Props {
   productImage: string;
   productName: string;
   productPrice: string;
-  daysLeft: string;
+  endDate: Date;
   membersLeft: string;
-  currentMembers?: number; // 현재 참여한 멤버 수
-  maxMembers?: number; // 최대 멤버 수
+  currentMembers?: number;
+  maxMembers?: number;
   isParty: boolean;
+  isSubscribed?: boolean;
+  onClick?: () => void;
 }
 
 export default function PartyCard({ 
   productImage, 
   productName, 
   productPrice, 
-  daysLeft, 
+  endDate,
   membersLeft, 
   currentMembers = 3,
   maxMembers = 6,
-  isParty = false
+  isParty = false,
+  isSubscribed = false,
+  onClick
 }: Props) {
-  
-  // 파티 아바타들을 렌더링하는 함수
-  const renderPartyAvatars = () => {
-    const avatars = [];
-    
-    // 현재 참여한 멤버들의 아바타
-    for (let i = 0; i < currentMembers; i++) {
-      avatars.push(
-        <PartyAvatar 
-          key={`member-${i}`} 
-          size="sm" 
-        />
-      );
-    }
-    
-    // 빈 자리들 (비활성화된 아바타)
-    for (let i = currentMembers; i < maxMembers; i++) {
-      avatars.push(
-        <PartyAvatar 
-          key={`empty-${i}`} 
-          size="sm" 
-          disabled 
-        />
-      );
-    }
-    
-    return avatars;
-  };
 
   return (
     <div className={s.container}>
-      <div className={s.header}></div>
-        <div className={s.product_id}>
-          <img src={productImage} alt={productName} width={26} height={26}/>
-          <Typo.BodyLarge>{productName}</Typo.BodyLarge>
-          <Typo.BodyLarge>{productPrice}원</Typo.BodyLarge>
-        </div>
-        {isParty && (
-          <div className={s.member}>
-          {renderPartyAvatars()}
-        </div>
-        )}
-        <div className={s.subscription}>
-          <Typo.Subtext>{daysLeft}</Typo.Subtext>
-          {isParty ? (
-            <Typo.Subtext>{membersLeft}자리 남음</Typo.Subtext>
-          ) : (
-            <Typo.Subtext>{membersLeft}명 참여중</Typo.Subtext>
-          )}
-        </div>
-        <Button size="large" variant="primary" fullWidth>파티 참여하기</Button>
+      <PartyCardHead 
+        productImage={productImage}
+        productName={productName}
+        productPrice={productPrice}
+        endDate={endDate}
+        isSubscribed={isSubscribed}
+      />
+      <PartyCardIsParty 
+        currentMembers={currentMembers}
+        maxMembers={maxMembers}
+        isParty={isParty}
+      />
+      <PartyCardInfo 
+        endDate={endDate}
+        membersLeft={membersLeft}
+        isParty={isParty}
+        isSubscribed={isSubscribed}
+      />
+      <PartyCardButton 
+        isParty={isParty}
+        isSubscribed={isSubscribed}
+        onClick={onClick}
+      />
     </div>
   )
 }

--- a/src/components/product/party-card/party-card-button/index.tsx
+++ b/src/components/product/party-card/party-card-button/index.tsx
@@ -1,0 +1,21 @@
+import { Button } from "@/components/ui";
+
+interface Props {
+  isParty: boolean;
+  isSubscribed: boolean;
+  onClick?: () => void;
+}
+
+export default function PartyCardButton({ isParty, isSubscribed, onClick }: Props) {
+  if (isSubscribed) {
+    return (
+      <Button size="medium" variant="tertiary" fullWidth onClick={onClick}>구독관리</Button>
+    );
+  }
+  
+  return (
+    <Button size="medium" variant="primary" fullWidth onClick={onClick}>
+      {isParty ? "파티 참가하기" : "구독하기"}
+    </Button>
+  );
+}

--- a/src/components/product/party-card/party-card-head/index.tsx
+++ b/src/components/product/party-card/party-card-head/index.tsx
@@ -1,0 +1,38 @@
+import s from "./styles.module.scss"
+
+import { Typo } from '@/components/ui';
+import { getRemainingDays } from '@/utils/date';
+
+interface Props {
+  productImage: string;
+  productName: string;
+  productPrice: string;
+  endDate: Date;
+  isSubscribed: boolean;
+}
+
+export default function PartyCardHead({ 
+  productImage, 
+  productName, 
+  productPrice, 
+  endDate, 
+  isSubscribed 
+}: Props) {
+  const remainingDays = getRemainingDays(endDate);
+  
+  return (
+    <div className={s.container}>
+        <div className={s.product_id}>
+          <img src={productImage} alt={productName} width={26} height={26}/>
+          <Typo.BodyLarge>{productName}</Typo.BodyLarge>
+          </div>
+          <div className={s.product_info}>
+          {isSubscribed ? (
+            <Typo.BodyLarge>{remainingDays}일 남음</Typo.BodyLarge>
+          ) : (
+            <Typo.BodyLarge>{productPrice}원</Typo.BodyLarge>
+          )}
+        </div>
+    </div>
+  );
+}

--- a/src/components/product/party-card/party-card-head/styles.module.scss
+++ b/src/components/product/party-card/party-card-head/styles.module.scss
@@ -1,0 +1,18 @@
+.container{
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    align-self: stretch;
+
+}
+img{
+    border-radius: 8px;
+}
+.product_id{
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: $spacing-10;
+}

--- a/src/components/product/party-card/party-card-info/index.tsx
+++ b/src/components/product/party-card/party-card-info/index.tsx
@@ -1,0 +1,36 @@
+import { Typo } from "@/components/ui";
+import { getPartyEndDateText, formatKoreanDate } from "@/utils/date";
+import s from "./styles.module.scss";
+
+interface Props {
+  endDate: Date;
+  membersLeft: string;
+  isParty: boolean;
+  isSubscribed: boolean;
+}
+
+export default function PartyCardInfo({ 
+  endDate,
+  membersLeft, 
+  isParty, 
+  isSubscribed 
+}: Props) {
+  const dateText = isSubscribed 
+    ? `${formatKoreanDate(endDate)}까지`  // 구독중: 2025.9.31까지
+    : getPartyEndDateText(endDate);       // 비구독: 2025.9.31까지(30일)
+
+  return (
+    <div className={s.subscription}>
+      <Typo.Subtext>{dateText}</Typo.Subtext>
+      {isParty ? (
+        isSubscribed ? (
+          <Typo.Subtext>계정공유</Typo.Subtext>
+        ) : (
+          <Typo.Subtext>{membersLeft}자리 남음</Typo.Subtext>
+        )
+      ) : (
+        <Typo.Subtext>개인 계정 적용</Typo.Subtext>
+      )}
+    </div>
+  );
+}

--- a/src/components/product/party-card/party-card-info/styles.module.scss
+++ b/src/components/product/party-card/party-card-info/styles.module.scss
@@ -1,0 +1,7 @@
+.subscription{
+    display: flex;
+justify-content: space-between;
+align-items: flex-start;
+align-self: stretch;
+color: $color-text-subtle;
+}

--- a/src/components/product/party-card/party-card-isparty/index.tsx
+++ b/src/components/product/party-card/party-card-isparty/index.tsx
@@ -1,0 +1,47 @@
+import PartyAvatar from "../../party-avatar";
+import s from "./styles.module.scss";
+
+interface Props {
+  currentMembers: number;
+  maxMembers: number;
+  isParty: boolean;
+}
+
+export default function PartyCardIsParty({ currentMembers, maxMembers, isParty }: Props) {
+    const renderPartyAvatars = () => {
+    const avatars = [];
+    
+    // 현재 참여한 멤버들의 아바타
+    for (let i = 0; i < currentMembers; i++) {
+      avatars.push(
+        <PartyAvatar
+          key={`member-${i}`} 
+          size="md" 
+        />
+      );
+    }
+    
+    // 빈 자리들 (비활성화된 아바타)
+    for (let i = currentMembers; i < maxMembers; i++) {
+      avatars.push(
+        <PartyAvatar 
+          key={`empty-${i}`} 
+          size="md" 
+          disabled 
+        />
+      );
+    }
+    
+    return avatars;
+  };
+  
+  return (
+    <div className={s.container}>
+    {isParty && (
+          <div className={s.member}>
+          {renderPartyAvatars()}
+        </div>
+        )}
+    </div>
+  );
+}

--- a/src/components/product/party-card/party-card-isparty/styles.module.scss
+++ b/src/components/product/party-card/party-card-isparty/styles.module.scss
@@ -1,0 +1,12 @@
+.container {
+    width: 100%;
+}
+
+.member{
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    flex-direction: row;
+    width: 100%;
+}
+

--- a/src/components/product/party-card/styles.module.scss
+++ b/src/components/product/party-card/styles.module.scss
@@ -1,27 +1,16 @@
 .container{
-  width: 370px;
+  width: 368px;
   padding: $spacing-20;
   gap: $spacing-20;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   border-radius: $radius-20;
-
-  .header{
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-    align-self: stretch;
-  }
+  border-radius: $radius-20;
+border: 1px solid #E8E8E8;
+box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.07);
   
-  .product_id{
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: $spacing-10;
-  }
+  
   
   .member{
     display: flex;

--- a/src/components/product/party-card/styles.module.scss
+++ b/src/components/product/party-card/styles.module.scss
@@ -1,116 +1,43 @@
-.partyCard {
-  width: 368px;
+.container{
+  width: 370px;
+  padding: $spacing-20;
+  gap: $spacing-20;
   display: flex;
   flex-direction: column;
-  gap: $spacing-20;
-  padding: $spacing-20;
-  border: 1px solid $color-border;
-  border-radius: 20px;
-  background: $color-surface;
-  box-shadow: $shadow;
+  align-items: flex-start;
+  border-radius: $radius-20;
 
-  &:hover {
-    background-color: $color-surface-subtle;
-    cursor: pointer;
+  .header{
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    align-self: stretch;
   }
-}
+  
+  .product_id{
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: $spacing-10;
+  }
+  
+  .member{
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: $spacing-12;
+  }
 
-.partyInfo {
-  display: flex;
+  .subscription{
+    width: 100%;
+    display: flex;
   justify-content: space-between;
-  align-items: center;
-  gap: $spacing-16;
-  width: 100%;
-}
-
-.partyInfoLeft {
-  display: flex;
-  align-items: center;
-  gap: $spacing-10;
-}
-
-.logo {
-  width: 26px;
-  height: 26px;
-  border-radius: 8px;
-  overflow: hidden;
-  flex-shrink: 0;
-
-  object-fit: cover;
-}
-
-.avatars {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  width: 100%;
-
-  color: $color-text-subtle;
-}
-// 반응형 디자인
-@media (max-width: 768px) {
-  .partyCard {
-    padding: 16px;
-    gap: 16px;
+  align-items: flex-start;
+  align-self: stretch;
   }
 
-  .title {
-    font-size: 16px;
-  }
-
-  .price {
-    font-size: 16px;
-  }
-
-  .avatars {
-    gap: 8px;
-  }
-
-  .footer {
-    gap: 16px;
-  }
-
-  .endDate,
-  .remainingSpots {
-    font-size: 13px;
-  }
-}
-
-@media (max-width: 480px) {
-  .partyCard {
-    padding: 12px;
-    gap: 12px;
-  }
-
-  .partyInfo {
-    gap: 12px;
-  }
-
-  .partyInfoLeft {
-    gap: 8px;
-  }
-
-  .logo {
-    width: 24px;
-    height: 24px;
-  }
-
-  .title {
-    font-size: 15px;
-  }
-
-  .price {
-    font-size: 15px;
-  }
-
-  .avatars {
-    gap: 6px;
-  }
+  
+  
 }

--- a/src/components/product/product-question/index.tsx
+++ b/src/components/product/product-question/index.tsx
@@ -21,8 +21,8 @@ export default function ProductQuestion(props: Product) {
         <Typo.Body>{question.description}</Typo.Body>
       </VStack>
       <HStack gap={12}>
-        {question.images.map((image) => (
-          <img src={image} alt={serviceName} className={styles.image} />
+        {question.images.map((image, index) => (
+          <img key={index} src={image} alt={serviceName} className={styles.image} />
         ))}
       </HStack>
     </HStack>

--- a/src/components/ui/button/index.tsx
+++ b/src/components/ui/button/index.tsx
@@ -5,7 +5,7 @@ import s from "./style.module.scss";
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: ReactNode;
   size?: "large" | "medium";
-  variant?: "primary" | "secondary";
+  variant?: "primary" | "secondary" | "tertiary";
   pending?: boolean;
   fullWidth?: boolean;
   leadingIcon?: ReactNode;

--- a/src/components/ui/button/style.module.scss
+++ b/src/components/ui/button/style.module.scss
@@ -74,6 +74,11 @@
 
       border: 1px solid $color-border;
     }
+
+    &.tertiary {
+      background-color: $color-surface-subtle;
+      color: $color-text-subtle;
+    }
   
     // Disabled state
     &.disabled {

--- a/src/mock/product/index.ts
+++ b/src/mock/product/index.ts
@@ -67,12 +67,14 @@ const createPlan = (
   price: number,
   discountRate = 10,
   participantCount?: number,
+  isIndividual = false, // 개인 구독 여부
 ) => {
   const discountPrice = Math.round(price * (1 - discountRate / 100));
-  const maxParticipants = 4;
-  // participantCount가 지정되지 않은 경우 0-3 사이의 랜덤한 수
-  const actualParticipantCount =
-    participantCount ?? Math.floor(Math.random() * maxParticipants);
+  const maxParticipants = isIndividual ? 1 : 4;
+  // participantCount가 지정되지 않은 경우 설정
+  const actualParticipantCount = isIndividual 
+    ? 0 // 개인 구독은 현재 참여자 0명
+    : (participantCount ?? Math.floor(Math.random() * maxParticipants));
 
   return {
     id,
@@ -101,7 +103,10 @@ export const MockProducts: Product[] = [
     gallery: ["/image/product/chatgpt.png"],
     popularProduct: true,
     mostUsedProduct: true,
-    plan: [createPlan("pl_ai_001", "Standard", 20000, 10, 2)],
+    plan: [
+      createPlan("pl_ai_001", "Party Plan", 20000, 10, 2),
+      createPlan("pl_ai_001_individual", "Individual Plan", 24000, 0, 0, true)
+    ],
     createdAt: createDate("2024-01-10"),
     updatedAt: createDate("2024-06-10"),
     question: {
@@ -177,7 +182,10 @@ export const MockProducts: Product[] = [
     gallery: ["/image/product/chatgpt.png"],
     popularProduct: true,
     mostUsedProduct: true,
-    plan: [createPlan("pl_music_001", "Standard", 13900, 10, 3)],
+    plan: [
+      createPlan("pl_music_001", "Party Plan", 13900, 10, 3),
+      createPlan("pl_music_001_individual", "Individual Plan", 16900, 0, 0, true)
+    ],
     createdAt: createDate("2024-02-01"),
     updatedAt: createDate("2024-06-20"),
     question: {
@@ -238,7 +246,10 @@ export const MockProducts: Product[] = [
     gallery: ["/image/product/chatgpt.png"],
     popularProduct: true,
     mostUsedProduct: true,
-    plan: [createPlan("pl_stream_001", "Premium", 17000, 10, 4)],
+    plan: [
+      createPlan("pl_stream_001", "Party Plan", 17000, 10, 4),
+      createPlan("pl_stream_001_individual", "Individual Plan", 20900, 0, 0, true)
+    ],
     createdAt: createDate("2024-03-01"),
     updatedAt: createDate("2024-06-28"),
     question: {

--- a/src/mock/subscription.ts
+++ b/src/mock/subscription.ts
@@ -1,0 +1,125 @@
+import { MockProducts } from "./product";
+
+// 사용자의 구독 정보 목 데이터
+export interface UserSubscription {
+  id: string;
+  productId: string;
+  planId: string;
+  startDate: Date;
+  endDate: Date;
+  status: "active" | "expired" | "cancelled";
+  isParty: boolean;
+  partyId?: string;
+  currentMembers?: number; // 현재 파티 멤버 수
+  maxMembers?: number;     // 최대 파티 멤버 수
+}
+
+export const MockUserSubscriptions: UserSubscription[] = [
+  {
+    id: "sub_001",
+    productId: "p_ai_001", // ChatGPT Plus
+    planId: "pl_ai_001",
+    startDate: new Date("2024-11-01"),
+    endDate: new Date("2025-06-15"), // 약 6개월 후
+    status: "active",
+    isParty: true,
+    partyId: "party_001",
+    currentMembers: 3,
+    maxMembers: 4
+  },
+  {
+    id: "sub_002", 
+    productId: "p_music_001", // Spotify Premium
+    planId: "pl_music_001",
+    startDate: new Date("2024-10-15"),
+    endDate: new Date("2027-04-20"), // 약 4개월 후
+    status: "active",
+    isParty: true,
+    partyId: "party_spotify",
+    currentMembers: 2,
+    maxMembers: 4
+  },
+  {
+    id: "sub_003",
+    productId: "p_stream_001", // Netflix
+    planId: "pl_stream_001", 
+    startDate: new Date("2024-09-01"),
+    endDate: new Date("2024-12-01"),
+    status: "expired",
+    isParty: true,
+    partyId: "party_002",
+    currentMembers: 4,
+    maxMembers: 4
+  },
+  {
+    id: "sub_004",
+    productId: "p_ai_002", // Claude Pro
+    planId: "pl_ai_002",
+    startDate: new Date("2024-11-10"),
+    endDate: new Date("2025-08-25"), // 약 8개월 후
+    status: "active",
+    isParty: true,
+    partyId: "party_003",
+    currentMembers: 2,
+    maxMembers: 4
+  },
+  {
+    id: "sub_005",
+    productId: "p_music_004", // YouTube Music (개인 구독)
+    planId: "pl_music_004",
+    startDate: new Date("2024-11-01"),
+    endDate: new Date("2025-05-01"), // 약 5개월 후
+    status: "active",
+    isParty: false,
+    currentMembers: 1,
+    maxMembers: 1
+  },
+  {
+    id: "sub_006",
+    productId: "p_ai_004", // Perplexity Pro (개인 구독)
+    planId: "pl_ai_004",
+    startDate: new Date("2024-10-20"),
+    endDate: new Date("2025-07-20"), // 약 7개월 후
+    status: "active",
+    isParty: false,
+    currentMembers: 1,
+    maxMembers: 1
+  }
+];
+
+// 구독 정보와 상품 정보를 조합하는 헬퍼 함수
+export const getSubscriptionWithProduct = () => {
+  return MockUserSubscriptions.map(subscription => {
+    const product = MockProducts.find(p => p.id === subscription.productId);
+    const plan = product?.plan.find(pl => pl.id === subscription.planId);
+    
+    return {
+      ...subscription,
+      product,
+      plan
+    };
+  }).filter(item => item.product && item.plan);
+};
+
+// 구독하지 않은 상품들을 반환하는 헬퍼 함수
+export const getUnsubscribedProducts = () => {
+  const subscribedProductIds = MockUserSubscriptions
+    .filter(sub => sub.status === "active")
+    .map(sub => sub.productId);
+  
+  return MockProducts
+    .filter(product => !subscribedProductIds.includes(product.id))
+    .map(product => {
+      // 각 상품의 첫 번째 플랜을 기본으로 사용
+      const plan = product.plan[0];
+      return {
+        product,
+        plan,
+        // 임시 구독 정보 (구독하지 않은 상태)
+        isSubscribed: false,
+        isParty: true, // 대부분 파티로 설정
+        currentMembers: Math.floor(Math.random() * 3) + 1, // 1-3명 랜덤
+        maxMembers: 4
+      };
+    });
+};

--- a/src/pages/product/product.tsx
+++ b/src/pages/product/product.tsx
@@ -47,14 +47,30 @@ export default function Product() {
         <VStack fullWidth gap={24}>
           <Typo.Headline as="h2">{product.name} 파티</Typo.Headline>
           <HStack gap={24} wrap>
-            {product.plan.map((party) => (
-              <PartyCard
-                key={party.id}
-                party={party}
-                productImage={product.image}
-                onClick={() => navigate(`/product/${id}/party/${party.id}`)}
-              />
-            ))}
+                        {product.plan.map((plan) => {
+              const isPartyPlan = plan.maxParticipants > 1;
+              return (
+                <PartyCard
+                  key={plan.id}
+                  productImage={product.image}
+                  productName={product.name}
+                  productPrice={plan.price.toString()}
+                  endDate={plan.endDate}
+                  membersLeft={(plan.maxParticipants - plan.participants.length).toString()}
+                  currentMembers={plan.participants.length}
+                  maxMembers={plan.maxParticipants}
+                  isParty={isPartyPlan}
+                  isSubscribed={false}
+                  onClick={() => {
+                    if (isPartyPlan) {
+                      navigate(`/product/${id}/party/${plan.id}`);
+                    } else {
+                      navigate(`/product/${id}`);
+                    }
+                  }}
+                />
+              );
+            })}
           </HStack>
         </VStack>
         <Spacing size={25} />

--- a/src/pages/subscription.tsx
+++ b/src/pages/subscription.tsx
@@ -1,19 +1,105 @@
+import { useNavigate } from "react-router-dom";
 import { MainLayout } from "@/components/layouts";
-import { Header } from "@/components/ui";
+import { PartyCard } from "@/components/product";
+import { Header, HStack, Spacing, Typo, VStack } from "@/components/ui";
+import { getSubscriptionWithProduct, getUnsubscribedProducts } from "@/mock/subscription";
 
 /**
- * Subscription page component that renders the header and main layout.
- *
- * Renders a Header followed by MainLayout containing the paragraph "나야 Subscription".
- *
- * @returns The page's JSX element.
+ * Subscription page component that shows user's current subscriptions.
  */
 export default function Subscription() {
+  const navigate = useNavigate();
+  const subscriptions = getSubscriptionWithProduct();
+  const activeSubscriptions = subscriptions.filter(sub => sub.status === "active");
+  const unsubscribedProducts = getUnsubscribedProducts();
+
+  // 구독과 미구독 상품이 모두 없을 때 예외 처리
+  if (activeSubscriptions.length === 0 && unsubscribedProducts.length === 0) {
+    return (
+      <>
+        <Header />
+        <Spacing size={25} />
+        <MainLayout gap={42}>
+          <Typo.Headline>표시할 상품이 없습니다.</Typo.Headline>
+        </MainLayout>
+      </>
+    );
+  }
+
   return (
     <>
       <Header />
-      <MainLayout>
-        <p>나야 Subscription</p>
+      <Spacing size={25} />
+      <MainLayout gap={42}>
+        {/* 내 구독 섹션 */}
+        {activeSubscriptions.length > 0 && (
+          <VStack fullWidth gap={24}>
+            <Typo.Headline as="h2">내 구독</Typo.Headline>
+            <HStack gap={24} wrap>
+              {activeSubscriptions.map((subscription) => {
+                const currentMembers = subscription.currentMembers || 0;
+                const maxMembers = subscription.maxMembers || 0;
+                const membersLeft = Math.max(0, maxMembers - currentMembers);
+                
+                return (
+                  <PartyCard
+                    key={subscription.id}
+                    productImage={subscription.product!.image}
+                    productName={subscription.product!.name}
+                    productPrice={subscription.plan!.price.toString()}
+                    endDate={subscription.endDate}
+                    membersLeft={membersLeft.toString()}
+                    currentMembers={currentMembers}
+                    maxMembers={maxMembers}
+                    isParty={subscription.isParty}
+                    isSubscribed={true}
+                    onClick={() => {
+                      if (subscription.isParty) {
+                        navigate(`/product/${subscription.productId}/party/${subscription.planId}`);
+                      } else {
+                        navigate(`/product/${subscription.productId}`);
+                      }
+                    }}
+                  />
+                );
+              })}
+            </HStack>
+          </VStack>
+        )}
+
+        {/* 구독 가능한 상품 섹션
+        {unsubscribedProducts.length > 0 && (
+          <VStack fullWidth gap={24}>
+            <Typo.Headline as="h2">구독 가능한 상품</Typo.Headline>
+            <HStack gap={24} wrap>
+              {unsubscribedProducts.map((item, index) => {
+                const membersLeft = Math.max(0, item.maxMembers - item.currentMembers);
+                
+                return (
+                  <PartyCard
+                    key={`unsubscribed-${item.product.id}-${index}`}
+                    productImage={item.product.image}
+                    productName={item.product.name}
+                    productPrice={item.plan.price.toString()}
+                    endDate={item.plan.endDate}
+                    membersLeft={membersLeft.toString()}
+                    currentMembers={item.currentMembers}
+                    maxMembers={item.maxMembers}
+                    isParty={item.isParty}
+                    isSubscribed={false}
+                    onClick={() => {
+                      if (item.isParty) {
+                        navigate(`/product/${item.product.id}/party/${item.plan.id}`);
+                      } else {
+                        navigate(`/product/${item.product.id}`);
+                      }
+                    }}
+                  />
+                );
+              })}
+            </HStack>
+          </VStack>
+        )} */}
       </MainLayout>
     </>
   );

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -26,11 +26,12 @@ export const getDaysDifference = (startDate: Date, endDate: Date): number => {
 };
 
 /**
- * 현재 날짜부터 특정 날짜까지 남은 일수를 계산합니다
+ * 현재 날짜부터 특정 날짜까지 남은 일수를 계산합니다 (음수 방지)
  */
 export const getRemainingDays = (targetDate: Date): number => {
   const today = new Date();
-  return getDaysDifference(today, targetDate);
+  const days = getDaysDifference(today, targetDate);
+  return Math.max(0, days); // 음수가 나오면 0으로 처리
 };
 
 /**


### PR DESCRIPTION
추가된거:
PartyCard 컴포넌트 존나 쌈뽕하게 만들었음.
내 구독 페이지 만들었음.
최소가격순으로 나열 가능한 getMinPlanPrice함수 만듦.

참고:
목데이터도 대충 만들었는데 내 구독페이지용으로 따로 만든거라 기존 목데이터랑 연결은 안됨.
(굳이 여기 시간 쓰는것도 이상하고)

잡소리:
만들면서 내 구독에서 어떤 가격대 상품을 긁었는지 한눈에 못본다는 점에서 아쉬운 소리가 나올거 같다는 생각이 들긴함.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Subscription page now lists your active subscriptions with plan details and quick navigation.
  - Product pages show per-plan cards with clear pricing, remaining seats, and party/individual distinctions.
- Bug Fixes
  - Remaining days no longer display negative values for past dates.
  - Improved image list rendering stability in product questions.
- Refactor
  - Party card reorganized for clearer layout and maintainability.
- Style
  - Updated party card visuals with refined layout and shadows.
  - Added a tertiary button style for subtle actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->