### PR TITLE
네이버로그인버튼 추가

### DIFF
--- a/public/naver.svg
+++ b/public/naver.svg
@@ -1,0 +1,3 @@
+<svg width="21" height="18" viewBox="0 0 21 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.851562 0.25V17.75H7.58461V8.99461L13.4437 17.75H20.1875V0.25H13.4437V8.99461L7.58461 0.25H0.851562Z" fill="white"/>
+</svg>

--- a/src/components/auth/login/login-modal.tsx
+++ b/src/components/auth/login/login-modal.tsx
@@ -1,9 +1,11 @@
-import { Button, Spacing } from "@/components/ui";
-
+import { Button, Spacing, Typo } from "@/components/ui";
+import { Link } from "react-router-dom";
+import { ChevronRight } from "lucide-react";
 import s from "./styles.module.scss";
+import { useState } from "react";
 
 export default function LoginModal() {
-
+ const [isKorea, setIsKorea] = useState(true);//한유찬이 로그인 누를때마다 알잘딱 나라 보내준다고함.
   return (
     <>
       <div className={s.container}>
@@ -15,6 +17,7 @@ export default function LoginModal() {
           size="large"
           variant="secondary"
           fullWidth
+          className={s.google_button}
           leadingIcon={
             <img
               src="/google.svg"
@@ -26,7 +29,7 @@ export default function LoginModal() {
         >
           구글로 시작하기
         </Button>
-        <Button
+        {isKorea && (<><Button
           size="large"
           variant="secondary"
           fullWidth
@@ -42,7 +45,29 @@ export default function LoginModal() {
         >
           카카오톡으로 시작하기
         </Button>
+        <Button
+          size="large"
+          variant="secondary"
+          fullWidth
+          className={s.naver_button}
+          leadingIcon={
+            <img
+              src="/naver.svg"
+              alt="naver"
+              style={{ width: "20px", height: "20px" }}
+            />
+          }
+          onClick={() => console.log("naver login")}
+        >
+          네이버로 시작하기
+        </Button>
+        </>)}
+        
         </div>
+        <Spacing size={8} />
+        <Link to="/auth/login/number" className={s.number_container}>
+            <Typo.BodyLarge>전화번호로 시작하기</Typo.BodyLarge> <ChevronRight size={21} />
+        </Link>
       </>
   );
 }

--- a/src/components/auth/login/styles.module.scss
+++ b/src/components/auth/login/styles.module.scss
@@ -24,3 +24,32 @@
 .kakao_button:hover {
   background-color: #FFE300 !important;
 }
+
+.google_button {
+  background-color: #FFFFFF !important;
+  color: #000000 !important;
+  border: 1px solid #E0E0E0 !important;
+}
+
+.google_button:hover {
+  background-color: #F5F5F5 !important;
+}
+
+.naver_button {
+  background-color: #06C75A !important;
+  color: #FFFFFF !important;
+  border: none !important;
+}
+
+.naver_button:hover {
+  background-color: #05B350 !important;
+}
+
+.number_container {
+  display: flex;
+  align-items: center;
+  gap: $spacing-4;
+  color: $color-text;
+  text-decoration: none;
+  cursor: pointer;
+}


### PR DESCRIPTION
추가:
네이버 로그인
전화번호 로그인
한국인지 아닌지 state값

한국일때는 네이버,카카오 보이고 외국이면 안보임

로그인버튼 누를때 백엔드에서 나라 어디인지 던져준다고함. 받으면 그거 걍 로컬에 저장하면 될 듯.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added Naver login option.
  * Region-aware display of login providers (Kakao/Naver shown for Korea).
  * Added phone number login entry with descriptive text and arrow icon.

* Style
  * Updated Google login button styling for improved clarity.
  * Added distinct styles for Naver login button.
  * Introduced styling for the phone number login link to align with the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->