### PR TITLE
포인트 입력에관하여여

### DIFF
--- a/src/components/billing/payment-modal/index.tsx
+++ b/src/components/billing/payment-modal/index.tsx
@@ -26,6 +26,7 @@ export default function PaymentModal({
   onClose,
 }: PaymentModalProps) {
   const [pointsToUse, setPointsToUse] = useState(0);
+  const [isFocused, setIsFocused] = useState(false);
 
   // 계산 관련 상수들
   const userPoints = 500; // 보유 포인트
@@ -84,12 +85,22 @@ export default function PaymentModal({
         <HStack gap={10} fullWidth>
           <Input
             placeholder="0P"
-            value={pointsToUse > 0 ? `${pointsToUse}P` : ""}
+            value={
+              isFocused
+                ? pointsToUse > 0
+                  ? pointsToUse.toString()
+                  : ""
+                : pointsToUse > 0
+                ? `${pointsToUse}P`
+                : ""
+            }
             onChange={(e) => {
               const value = e.target.value.replace(/[^0-9]/g, "");
               const numValue = parseInt(value) || 0;
               setPointsToUse(Math.min(numValue, userPoints, plan?.price || 0));
             }}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
             size="large"
             fullWidth
           />


### PR DESCRIPTION
포인트입력할때 지우는 과정에서는 'ㅖ'라는 문자 때문에 숫자가 안지워졌음.
그럼 사용자가 방향키로 이동해서 포인터를 숫자 바로 뒤로 다시 조정한후 백스페이스 눌러야 했는데

인풋이 선택되어있을때는 P가 안보이고 인풋이활성화되어있지 않을때는 P가 보이도록 만듦

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved points input in the Payment modal: shows plain digits while typing (focused), formats as “X P” when not focused, and remains empty when the value is zero.
  - Added focus/blur handling to deliver a clearer, more intuitive input experience without altering calculations or change events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->