### PR TITLE
Checkbox style

### DIFF
--- a/src/components/billing/payment-modal/index.tsx
+++ b/src/components/billing/payment-modal/index.tsx
@@ -26,6 +26,7 @@ export default function PaymentModal({
   onClose,
 }: PaymentModalProps) {
   const [pointsToUse, setPointsToUse] = useState(0);
+  const [isFocused, setIsFocused] = useState(false);
 
   // 계산 관련 상수들
   const userPoints = 500; // 보유 포인트
@@ -84,12 +85,22 @@ export default function PaymentModal({
         <HStack gap={10} fullWidth>
           <Input
             placeholder="0P"
-            value={pointsToUse > 0 ? `${pointsToUse}P` : ""}
+            value={
+              isFocused
+                ? pointsToUse > 0
+                  ? pointsToUse.toString()
+                  : ""
+                : pointsToUse > 0
+                ? `${pointsToUse}P`
+                : ""
+            }
             onChange={(e) => {
               const value = e.target.value.replace(/[^0-9]/g, "");
               const numValue = parseInt(value) || 0;
               setPointsToUse(Math.min(numValue, userPoints, plan?.price || 0));
             }}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
             size="large"
             fullWidth
           />

--- a/src/components/ui/checkbox/index.tsx
+++ b/src/components/ui/checkbox/index.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from "react";
 
+import { Typo } from "@/components/ui";
 import s from "./style.module.scss";
 
 export type CheckboxSize = "sm" | "md" | "lg";
@@ -130,16 +131,20 @@ export default function Checkbox(props: CheckboxProps) {
 
       {(label || description || error) && (
         <span className={s.texts}>
-          {label && <span className={s.label}>{label}</span>}
+          {label && (
+            <Typo.Body className={s.label}>
+              {label}
+            </Typo.Body>
+          )}
           {description && (
-            <span id={descriptionId} className={s.description}>
+            <Typo.Caption id={descriptionId} className={s.description}>
               {description}
-            </span>
+            </Typo.Caption>
           )}
           {error && (
-            <span id={errorId} className={s.errorText}>
+            <Typo.Caption id={errorId} className={s.errorText}>
               {error}
-            </span>
+            </Typo.Caption>
           )}
         </span>
       )}

--- a/src/components/ui/checkbox/style.module.scss
+++ b/src/components/ui/checkbox/style.module.scss
@@ -1,7 +1,7 @@
 .wrapper {
     display: inline-flex;
     align-items: flex-start;
-    gap: 10px;
+    gap: 8px;
     cursor: pointer;
     user-select: none;
     -webkit-tap-highlight-color: transparent;
@@ -53,8 +53,6 @@
   .sm {
     .box { width: 16px; height: 16px; border-radius: 4px; }
     .icon { width: 12px; height: 12px; }
-    .label { font-size: 13px; }
-    .description { font-size: 12px; }
   }
   
   .md {
@@ -63,9 +61,8 @@
   }
   
   .lg {
-    .box { width: 24px; height: 24px; border-radius: 6px; }
+    .box { width: 22px; height: 22px; border-radius: 6px; }
     .icon { width: 18px; height: 18px; }
-    .label { font-size: 16px; }
   }
   
   .texts {


### PR DESCRIPTION
아래 사용된 모든 단어는 체크박스 컴포넌트 구성요소로 한정됨.(ex 레이아웃 = 메인레이아웃x , 체크박스 레이아웃o)

체크박스 크기가 24px에서 22px로 변경 (내부 아이콘은 변경 사항 없음)

레이아웃 Gap이 8px로 변경(아이콘과 텍스트사이의 gap)

텍스트를 타이포그래피Body를 받도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved points input in Payment Modal: shows plain number while editing and adds “P” when not focused; validation against available points and plan price remains.

- Style
  - Updated Checkbox typography to standard text styles for label, description, and errors.
  - Adjusted Checkbox spacing and sizes: reduced gap between box and text, smaller large-size checkbox, and streamlined font sizing for small/large variants for visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->